### PR TITLE
[GST-2195] Upgraded to Ansible 2.1.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   - ANSIBLE_INSTALL_VERSION=1.9.4
   - ANSIBLE_INSTALL_VERSION=2.0.0.2
   - ANSIBLE_INSTALL_VERSION=2.0.2.0
+  - ANSIBLE_INSTALL_VERSION=2.1.1.0
   
 before_install:
   # Make sure everything's up to date.

--- a/README.md
+++ b/README.md
@@ -95,3 +95,11 @@ With AWS EC2 plugin:
             Stack: "services-dev-elasticsearch-v2"
           ec2_ping_timeout: "30s"
 ```
+
+
+
+
+## Test
+
+To run the test locally, run `make test`. This requires `ansible-lint` to be present. You can install `ansible-lint` with `pip install ansible-lint`.
+You may consider using a virtual python environment (i.e. use `virtualenv`). Review the `Makefile` to discover the other related `make` commands.

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,7 +24,7 @@
   apt:
     name: "{{ item }}"
     state: installed
-  with_items: elasticsearch.packages
+  with_items: "{{ elasticsearch.packages }}"
   notify: restart elasticsearch
 
 - name: Install Elasticsearch 1.x plugins
@@ -35,7 +35,7 @@
     creates: "/usr/share/elasticsearch/plugins/{{ item.plugin_dir }}"
   environment:
     JAVA_HOME: /usr/share/java
-  with_items: elasticsearch.plugins
+  with_items: "{{ elasticsearch.plugins }}"
   when: elasticsearch.family != '2.x'
 
 - name: Install Elasticsearch 2.x plugins
@@ -46,7 +46,7 @@
     creates: "/usr/share/elasticsearch/plugins/{{ item.plugin_dir }}"
   environment:
     JAVA_HOME: /usr/share/java
-  with_items: elasticsearch.plugins
+  with_items: "{{ elasticsearch.plugins }}"
   when: elasticsearch.family == '2.x'
 
 - name: Ensure some required directories


### PR DESCRIPTION
Made code changes to upgrade to Ansible 2.1.1 and added documentation that `ansible-lint` is required for `make test` to succeed.