### PR TITLE
[MP-432] Bind elastic globally but advertise the eth0 address

### DIFF
--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -13,10 +13,8 @@ index.number_of_replicas: {{ elasticsearch.index.number_of_replicas }}
 
 {% if elasticsearch.family is defined %}
 {% if elasticsearch.family == "2.x" %}
-{% if elasticsearch.network_host is defined %}
-network.host: {{ elasticsearch.network_host }}
-{% endif %}
-network.host: "_site:ipv4_"
+network.bind_host:    "0.0.0.0"
+network.publish_host: "_site:ipv4_"
 {% endif %}
 {% endif %}
 


### PR DESCRIPTION
Found that although things were clustering ansible was failing its final check against `127.0.0.1:9200`


This change makes elastic bind globally to `0.0.0.0` so we can still work on elk using *localhost* but will ensure the servers advertise their primary (eth0) IPs... this is per the 2.0 documentation so should work for the whole 2.x family also.

ref: https://www.elastic.co/guide/en/elasticsearch/reference/2.0/modules-network.html