### PR TITLE
[GITHUB-15] Switch Backup Script to Syslog

### DIFF
--- a/tasks/install/1.x.yml
+++ b/tasks/install/1.x.yml
@@ -32,7 +32,7 @@
   command: "/usr/share/elasticsearch/bin/plugin -install {{ item.plugin_name }}"
   args:
     chdir: /usr/share/elasticsearch/
-    creates: "/usr/share/elasticsearch/plugins/{{ item.plugin_dir }}"
+    creates: "/usr/share/elasticsearch/plugins/{{ item.plugin_dir | default(item.plugin_name) }}"
   environment:
     JAVA_HOME: /usr/share/java
   with_items: "{{ elasticsearch.plugins }}"

--- a/tasks/install/2.x.yml
+++ b/tasks/install/2.x.yml
@@ -24,7 +24,7 @@
   command: "/usr/share/elasticsearch/bin/plugin install {{ item.plugin_name }}"
   args:
     chdir: /usr/share/elasticsearch/
-    creates: "/usr/share/elasticsearch/plugins/{{ item.plugin_dir }}"
+    creates: "/usr/share/elasticsearch/plugins/{{ item.plugin_dir | default(item.plugin_name) }}"
   environment:
     JAVA_HOME: /usr/share/java
   with_items: "{{ elasticsearch.plugins }}"

--- a/tasks/install/5.x.yml
+++ b/tasks/install/5.x.yml
@@ -24,7 +24,7 @@
   command: "/usr/share/elasticsearch/bin/elasticsearch-plugin install {{ item.plugin_name }}"
   args:
     chdir: /usr/share/elasticsearch/
-    creates: "/usr/share/elasticsearch/plugins/{{ item.plugin_dir }}"
+    creates: "/usr/share/elasticsearch/plugins/{{ item.plugin_dir | default(item.plugin_name) }}"
   environment:
     JAVA_HOME: /usr/share/java
   with_items: "{{ elasticsearch.plugins }}"

--- a/templates/aws_s3_snapshot.sh.j2
+++ b/templates/aws_s3_snapshot.sh.j2
@@ -3,45 +3,64 @@ set -o nounset
 set -o errexit
 
 export PATH=$PATH:/usr/sbin:/sbin:/usr/bin:/bin:/usr/local/bin/
+readonly LOGGER_TAG="aws-s3-snapshot"
+quiet=0
 
-function info { echo -e "$( date +%T )" "\033[1;33m  $1\033[0m"; }
-function ok { echo -e "$( date +%T )" "\033[1;32m  $1\033[0m"; }
-function error { echo -e "$( date +%T )" "\033[1;31m  Error: $1\033[0m"; }
+while getopts "q" opt; do
+	case "$opt" in
+	q)  quiet=1
+		;;
+	esac
+done
+
+function info {
+	logger -p user.info -t "${LOGGER_TAG}" "$1";
+	if [ $quiet -eq 0 ]; then
+		echo -e "$( date +%T )" "\033[1;33m  $1\033[0m";
+	fi
+}
+function error {
+	logger -p user.error -t "${LOGGER_TAG}" "$1";
+	if [ $quiet -eq 0 ]; then
+		echo -e "$( date +%T )" "\033[1;31m  Error: $1\033[0m";
+	fi
+}
 function die { error "$1"; exit 1; }
 
 function main {
 	AWS_DEFAULT_REGION="{{ elasticsearch.s3_backup.region }}"
-	SNAPSHOP_BUCKET="{{ elasticsearch.s3_backup.bucket }}"
-	SNAPSHOP_BASE_PATH="{{ elasticsearch.s3_backup.base_path }}"
+	SNAPSHOT_BUCKET="{{ elasticsearch.s3_backup.bucket }}"
+	SNAPSHOT_BASE_PATH="{{ elasticsearch.s3_backup.base_path }}"
 	SERVER="http://localhost:{{ elasticsearch.port }}"
 
 	snapshot_repo_data="{
 		\"type\": \"s3\",
 		\"settings\": {
-			\"bucket\": \"${SNAPSHOP_BUCKET}\",
+			\"bucket\": \"${SNAPSHOT_BUCKET}\",
 			\"region\": \"${AWS_DEFAULT_REGION}\",
-			\"base_path\": \"${SNAPSHOP_BASE_PATH}\"
+			\"base_path\": \"${SNAPSHOT_BASE_PATH}\"
 		}
 	}"
-	response="$( echo "${snapshot_repo_data}" | curl -XPUT \
+	info "Creating snapshot repo"
+	response="$( echo "${snapshot_repo_data}" | curl -s -XPUT \
 		-d @- \
-		${SERVER}/_snapshot/${SNAPSHOP_BUCKET} )"
+		"${SERVER}/_snapshot/${SNAPSHOT_BUCKET}" )"
 
 	if [[ $response == *"acknowledged"* ]]; then
-		ok "Snapshot repo ready"
+		info "Snapshot repo ready"
 	else
-		echo "${response}"
+		error "${response}"
 		die "Error creating snapshot repo"
 	fi
 
-	snapshot_name="snapshop-all-$( date +%y-%m-%d-%s )"
+	snapshot_name="snapshot-all-$( date +%y-%m-%d-%s )"
 
-	info "Creating snapshop ${snapshot_name}"
-	response="$( curl -XPUT ${SERVER}/_snapshot/${SNAPSHOP_BUCKET}/${snapshot_name}?wait_for_completion=true )"
+	info "Creating SNAPSHOT ${snapshot_name}"
+	response="$( curl -s -XPUT "${SERVER}/_snapshot/${SNAPSHOT_BUCKET}/${snapshot_name}?wait_for_completion=true" )"
 	if [[ $response == *"\"failed\":0"* ]]; then
-		ok "Snapshot ready"
+		info "Snapshot ready"
 	else
-		echo "${response}"
+		error "${response}"
 		die "Error creating snapshot"
 	fi
 }

--- a/tests/vars_elasticsearch_5.0.yml
+++ b/tests/vars_elasticsearch_5.0.yml
@@ -1,6 +1,6 @@
 ---
 
 elasticsearch:
-  version: 5.0.0
+  version: 5.1.*
   family: 5.x
   plugins: [ ]


### PR DESCRIPTION
The AWS S3 backup script now writes to syslog instead of stdout.
Errors goes to both stderr and syslog.