### PR TITLE
Update users_and_groups dependency

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -2,11 +2,15 @@
 
 dependencies:
   - role: sansible.users_and_groups
-    version: v1.1
+    version: v1.4
     users_and_groups:
       users:
         - name: "{{ elasticsearch.user }}"
           gecos: Elasticsearch user
+      groups: []
+      sudoers: []
+      whitelist_groups: []
+      authorized_keys_dir:
     tags:
       - build
 


### PR DESCRIPTION
users_and_groups role v1.0 does not work anymore with Ansible 2.2.
Moreover, default variable values must be set.