### PR TITLE
[GITHUB-21] Fixes new lines in config files

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 
+sansible_elasticsearch_additional_config: ~
 sansible_elasticsearch_config_cluster_name: default_es_cluster
 sansible_elasticsearch_config_node_name: "{{ ansible_hostname }}"
 sansible_elasticsearch_config_path_data: /var/lib/elasticsearch

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -15,3 +15,8 @@
 
   roles:
     - role: elasticsearch
+      sansible_elasticsearch_additional_config:
+        bootstrap.mlockall: yes
+        index.number_of_shards: 1
+        index.number_of_replicas: 1
+        script.groovy.sandbox.enabled: yes

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -17,4 +17,4 @@ def test_listening(host):
 def test_elasticsearch(host):
     es = host.process.get(user='elastic+', comm='java')
     es_limits = host.file('/proc/%i/limits' % es.pid).content_string
-    assert re.search(r'Max open files\s+65536\s+65536\s+', es_limits)
+    assert re.search(r'Max open files\s+65535\s+65535\s+', es_limits)

--- a/templates/1.x/elasticsearch.default.j2
+++ b/templates/1.x/elasticsearch.default.j2
@@ -7,9 +7,9 @@ DATA_DIR={{ sansible_elasticsearch_paths_data }}
 ES_HOME=/usr/share/elasticsearch
 ES_USER={{ sansible_elasticsearch_user }}
 LOG_DIR={{ sansible_elasticsearch_paths_logs }}
-{%- if ansible_virtualization_type != 'docker' -%}
+{% if ansible_virtualization_type != 'docker' %}
 MAX_MAP_COUNT=262144
-{%- endif -%}
+{% endif %}
 MAX_OPEN_FILES={{ sansible_elasticsearch_limits_nofile_hard }}
 WORK_DIR=/tmp/elasticsearch
 

--- a/templates/2.x/elasticsearch.default.j2
+++ b/templates/2.x/elasticsearch.default.j2
@@ -7,9 +7,9 @@ DATA_DIR={{ sansible_elasticsearch_paths_data }}
 ES_HOME=/usr/share/elasticsearch
 ES_USER={{ sansible_elasticsearch_user }}
 LOG_DIR={{ sansible_elasticsearch_paths_logs }}
-{%- if ansible_virtualization_type != 'docker' -%}
+{% if ansible_virtualization_type != 'docker' %}
 MAX_MAP_COUNT=262144
-{%- endif -%}
+{% endif %}
 MAX_OPEN_FILES={{ sansible_elasticsearch_limits_nofile_hard }}
 WORK_DIR=/tmp/elasticsearch
 

--- a/templates/5.x/elasticsearch.default.j2
+++ b/templates/5.x/elasticsearch.default.j2
@@ -10,9 +10,9 @@ ES_USER={{ sansible_elasticsearch_user }}
 #JAVA_HOME=
 LOG_DIR={{ sansible_elasticsearch_paths_logs }}
 #MAX_LOCKED_MEMORY=unlimited
-{%- if ansible_virtualization_type != 'docker' -%}
+{% if ansible_virtualization_type != 'docker' %}
 MAX_MAP_COUNT=262144
-{%- endif -%}
+{% endif %}
 MAX_OPEN_FILES={{ sansible_elasticsearch_limits_nofile_hard }}
 PID_DIR={{ sansible_elasticsearch_paths_pid }}
 RESTART_ON_UPGRADE=true

--- a/templates/elasticsearch.yml.j2
+++ b/templates/elasticsearch.yml.j2
@@ -1,18 +1,10 @@
 ---
 # {{ ansible_managed }}
 # file: elasticsearch/templates/elasticsearch.yml.j2
-# jinja2:trim_blocks: False
 
-cluster:
-  name: {{ sansible_elasticsearch_config_cluster_name }}
-
-node:
-  name: {{ sansible_elasticsearch_config_node_name }}
-
-path:
-  data: {{ sansible_elasticsearch_config_path_data }}
-  logs: {{ sansible_elasticsearch_config_path_logs }}
-
-{%- if sansible_elasticsearch_additional_config is defined -%}
-{{ sansible_elasticsearch_additional_config | to_nice_yaml }}
-{%- endif -%}
+{{ sansible_elasticsearch_additional_config | default({}) | combine({
+  "cluster.name": sansible_elasticsearch_config_cluster_name,
+  "node.name": sansible_elasticsearch_config_node_name,
+  "path.data": sansible_elasticsearch_config_path_data,
+  "path.logs": sansible_elasticsearch_config_path_logs
+}) | to_nice_yaml }}


### PR DESCRIPTION
Fixes an issue with Jinja removing new lines resulting in broken
config files eg.

```YAML
---

cluster.name: default_es_cluster
node.name: ip-192-168-210-159
path.data: /var/lib/elasticsearch
path.logs: /var/log/elasticsearchbootstrap.mlockall: 'true'
cloud.aws.region: eu-west-1
cloud.node.auto_attributes: 'true'
```