### PR TITLE
[GITHUB-26] Fixes GPG key task

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,7 @@
 ---
 
 - src: sansible.java
-  version: v2.0
+  version: v2.1.2
 
 - src: sansible.users_and_groups
-  version: v2.0
+  version: v2.0.2

--- a/tasks/install/1.x.yml
+++ b/tasks/install/1.x.yml
@@ -3,7 +3,7 @@
 - name: Add Elastic gpg key
   become: yes
   apt_key:
-    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
 
 - name: Install Elasticsearch repo (ansible >= 2.0)

--- a/tasks/install/2.x.yml
+++ b/tasks/install/2.x.yml
@@ -3,7 +3,7 @@
 - name: Add Elastic gpg key
   become: yes
   apt_key:
-    url: https://packages.elastic.co/GPG-KEY-elasticsearch
+    url: https://artifacts.elastic.co/GPG-KEY-elasticsearch
     state: present
 
 - name: Install Elasticsearch repo


### PR DESCRIPTION
The SSL cert for the GPG key seems to no longer work for
packages., updating to artifacts. seems to fix this issue.